### PR TITLE
BGP: add EVPN address family

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ frr_ip_forwarding: true
 frr_ipv6_forwarding: true
 ```
 
+#### Next-hop tracking via default
+Resolve nexthops using the default route;
+useful if BGP peer is only reachable via default gateway (disabled by default).
+
+To enable:
+```yaml
+frr_nht_resolve_default: true
+```
+
 ### Prefix Lists
 
 #### Configuring Prefix Lists
@@ -235,6 +244,9 @@ frr_bgp:
         - "maximum-paths 2"
       af_v6:
         - "maximum-paths 2"
+      af_evpn:
+        - "advertise-all-vni"
+        - "rd {{ frr_router_id }}:1"
       neighbors:
         192.168.250.11:
           asn: 65000
@@ -256,6 +268,14 @@ frr_bgp:
           af_v6:
             - "activate"
             - "soft-reconfiguration inbound"
+        172.16.250.10:
+          asn: internal
+          timers_connect: 5
+          description: "L2VPN EVPN neighbor"
+          af_evpn:
+            - "activate"
+          other:
+            - "capability extended-nexthop"
       networks:
         - "{{ frr_router_id }}/32"
         - "{{ hostvars[inventory_hostname]['ansible_enp0s8']['ipv4']['address'] }}/24"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,14 @@ frr_bgp: {}
   #         v4_route_reflector_client: true
   #         other:
   #           - "prefix-list Bad_IPs in"
+  #       172.16.250.10:
+  #         asn: internal
+  #         timers_connect: 5
+  #         description: "L2VPN EVPN neighbor"
+  #         af_evpn:
+  #           - "activate"
+  #         other:
+  #           - "capability extended-nexthop"
   #     listen_range:
   #       192.168.250.0/24: any_peer_group
   #       "2600::/64": any_v6_peer_group
@@ -113,6 +121,9 @@ frr_static: {}
   # 2.2.2.2:
   #   192.168.0.1
 frr_static_v6: {}
+
+# Nexthop tracking via default gateway - disabled by default.
+frr_nht_resolve_default: false
 
 frr_package_url: "https://github.com/FRRouting/frr/releases/download/frr-{{ frr_version }}"
 

--- a/templates/etc/frr/frr.conf.j2
+++ b/templates/etc/frr/frr.conf.j2
@@ -65,6 +65,10 @@ ip forwarding
 ipv6 forwarding
 {% endif %}
 !
+{% if frr_nht_resolve_default | default(False) %}
+ip nht resolve-via-default
+{% endif %}
+!
 {% if frr_daemons['bgpd'] %}
 {%   if frr_bgp is defined and frr_bgp != {} %}
 {%     for asn, asn_data in frr_bgp['asns'].items() %}
@@ -103,6 +107,13 @@ router bgp {{ asn }}
 {%       if asn_data['af_v6'] | default(False) %}
   address-family ipv6 unicast
 {%         for option in asn_data['af_v6'] %}
+    {{ option }}
+{%         endfor %}
+  exit-address-family
+{%       endif %}
+{%       if asn_data['af_evpn'] | default(False) %}
+  address-family l2vpn evpn
+{%         for option in asn_data['af_evpn'] %}
     {{ option }}
 {%         endfor %}
   exit-address-family
@@ -163,6 +174,13 @@ router bgp {{ asn }}
 {%           if neighbor_data['af_v6'] | default(False) %}
   address-family ipv6 unicast
 {%             for option in neighbor_data['af_v6'] %}
+    neighbor {{ neighbor }} {{ option }}
+{%             endfor %}
+  exit-address-family
+{%           endif %}
+{%           if neighbor_data['af_evpn'] | default(False) %}
+  address-family l2vpn evpn
+{%             for option in neighbor_data['af_evpn'] %}
     neighbor {{ neighbor }} {{ option }}
 {%             endfor %}
   exit-address-family


### PR DESCRIPTION
Added:
-  `address-family l2vpn evpn` section to bgp
-  `ip nht resolve-via-default` knob to resolve remote bgp nexthops via default route.