### PR TITLE
frr config: add option to clear bgp on config change

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -181,6 +181,9 @@ frr_no_ebgp_requires_policy: false
 # Reloads frr upon config changes
 frr_reload: true
 
+# Performs a "clear ip bgp * soft out" on config file changes
+frr_clear_bgp_on_change: false
+
 # Enable ipv/ipv6 forwarding
 frr_ip_forwarding: true
 frr_ipv6_forwarding: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -25,6 +25,13 @@
   become: true
   listen: "start frr"
 
+- name: Clear bgp frr
+  ansible.builtin.shell:
+    cmd: 'vtysh -c "clear ip bgp * soft out"'
+  become: true
+  listen: "clear bgp frr"
+  when: frr_clear_bgp_on_change
+
 ## Quagga restart
 - name: Full restart quagga
   ansible.builtin.service:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -48,6 +48,7 @@
   notify:
     - reload frr
     - start frr
+    - clear bgp frr
 
 - name: Config | Ensure FRR service is enabled
   ansible.builtin.service:


### PR DESCRIPTION
This adds an option, disabled by default, to "clear ip bgp * soft out" when frr.conf changes.  Open to suggestions on better ways to implement this, but it works.